### PR TITLE
Feature/1 undo redo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { ReactFlow, Background, Controls, MiniMap } from "@xyflow/react";
+import {ReactFlow, Background, Controls, MiniMap} from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { MindMapNode } from "./components/mind-map-node";
-import { Sidebar } from "./components/sidebar";
-import { Header } from "./components/header";
-import { useAtom } from "jotai";
+import {MindMapNode} from "./components/mind-map-node";
+import {Sidebar} from "./components/sidebar";
+import {Header} from "./components/header";
+import {useAtom} from "jotai";
 import {
   nodesAtom,
   edgesAtom,
@@ -28,49 +28,59 @@ function App() {
   const [, onConnect] = useAtom(connectAtom);
 
   return (
-    <div className="flex flex-col h-screen">
-      <Header />
-      <div className="flex flex-1 overflow-hidden">
-        <div className="flex-1 h-full bg-[url('/grass-texture.png')] bg-repeat">
-          <ReactFlow
-            nodes={nodes}
-            edges={edges}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
-            onConnect={onConnect}
-            nodeTypes={nodeTypes}
-            fitView
-            minZoom={0.5}
-            maxZoom={2}
-            nodesDraggable={true}
-            elementsSelectable={true}
-            snapToGrid={true}
-            snapGrid={[15, 15]}
-            onNodeClick={(_, node) => {
-              setSelectedNode({
-                id: node.id,
-                data: node.data,
-                position: node.position,
-              });
-            }}
-            onPaneClick={() => setSelectedNode(null)}
-            proOptions={{ hideAttribution: true }}
-          >
-            <Background color="#a1a1aa" gap={16} size={1} />
-            <Controls className="p-1 rounded-md border-2 border-muted-foreground" />
-            <MiniMap
-              nodeColor={(n) => {
-                if (n.id === "root") return "#333";
-                return "#ccc";
-              }}
-              maskColor="rgba(255, 255, 255, 0.5)"
-              className="rounded-md border-2 border-muted-foreground"
-            />
-          </ReactFlow>
+    <>
+      <div className="md:hidden flex items-center justify-center h-screen p-4 bg-muted">
+        <div className="text-center space-y-4">
+          <h2 className="text-xl font-bold">My Mind-Map</h2>
+          <p className="text-sm text-muted-foreground">
+            このアプリはタブレット以上の画面サイズでご利用ください
+          </p>
         </div>
-        <Sidebar />
       </div>
-    </div>
+      <div className="hidden md:flex flex-col h-screen">
+        <Header />
+        <div className="flex flex-1 overflow-hidden">
+          <main className="flex-1 h-full bg-[url('/grass-texture.png')] bg-repeat">
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onConnect={onConnect}
+              nodeTypes={nodeTypes}
+              fitView
+              minZoom={0.5}
+              maxZoom={2}
+              nodesDraggable={true}
+              elementsSelectable={true}
+              snapToGrid={true}
+              snapGrid={[15, 15]}
+              onNodeClick={(_, node) => {
+                setSelectedNode({
+                  id: node.id,
+                  data: node.data,
+                  position: node.position,
+                });
+              }}
+              onPaneClick={() => setSelectedNode(null)}
+              proOptions={{hideAttribution: true}}
+            >
+              <Background color="#a1a1aa" gap={16} size={1} />
+              <Controls className="p-1 rounded-md border-2 border-muted-foreground" />
+              <MiniMap
+                nodeColor={(n) => {
+                  if (n.id === "root") return "#333";
+                  return "#ccc";
+                }}
+                maskColor="rgba(255, 255, 255, 0.5)"
+                className="rounded-md border-2 border-muted-foreground"
+              />
+            </ReactFlow>
+          </main>
+          <Sidebar />
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,24 +1,35 @@
-import { Button } from "@/components/ui/button";
+import {Button} from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
+import {Input} from "@/components/ui/input";
 import {
   addChildNodeAtom,
+  canRedoAtom,
+  canUndoAtom,
   deleteNodeAtom,
+  redoAtom,
   resetMindMapAtom,
   selectedNodeAtom,
+  undoAtom,
   updateNodeLabelAtom,
 } from "@/store/mind-map-store";
-import { useAtom } from "jotai";
-import { Pen, Plus, RefreshCw, Trash } from "lucide-react";
-import { useState } from "react";
+import {useAtom} from "jotai";
+import {Pen, Plus, Redo, RefreshCw, Trash, Undo} from "lucide-react";
+import {useEffect, useState} from "react";
+import {Separator} from "./ui/separator";
 
 export function Header() {
+  const [, undo] = useAtom(undoAtom);
+  const [, redo] = useAtom(redoAtom);
+  const [canUndo] = useAtom(canUndoAtom);
+  const [canRedo] = useAtom(canRedoAtom);
+
   const [selectedNode] = useAtom(selectedNodeAtom);
   const [, addChildNode] = useAtom(addChildNodeAtom);
   const [, updateNodeLabel] = useAtom(updateNodeLabelAtom);
@@ -28,6 +39,23 @@ export function Header() {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
   const [newLabel, setNewLabel] = useState("");
+
+  // キーボードショートカット
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+      }
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === "z") {
+        e.preventDefault();
+        redo();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [undo, redo]);
 
   const handleUpdateLabel = () => {
     if (selectedNode && newLabel.trim()) {
@@ -55,9 +83,7 @@ export function Header() {
 
         <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
           <DialogTrigger asChild>
-            <Button 
-            disabled={!selectedNode} 
-            >
+            <Button disabled={!selectedNode}>
               編集
               <Pen className="w-4 h-4" />
             </Button>
@@ -65,6 +91,9 @@ export function Header() {
           <DialogContent className="sm:max-w-[425px]">
             <DialogHeader>
               <DialogTitle>✏️ 内容を更新：</DialogTitle>
+              <DialogDescription>
+                ノードのラベルを編集してください
+              </DialogDescription>
             </DialogHeader>
             <div className="grid grid-cols-4 items-center gap-2 mt-2">
               <Input
@@ -89,7 +118,29 @@ export function Header() {
       </div>
 
       <div className="flex gap-2">
-      <Dialog open={isResetDialogOpen} onOpenChange={setIsResetDialogOpen}>
+        {/* 既存のボタンの前に追加 */}
+        <div className="flex gap-2">
+          <Button
+            onClick={undo}
+            disabled={!canUndo}
+            size="sm"
+            variant="outline"
+          >
+            <Undo className="w-4 h-4" />
+          </Button>
+          <Button
+            onClick={redo}
+            disabled={!canRedo}
+            size="sm"
+            variant="outline"
+          >
+            <Redo className="w-4 h-4" />
+          </Button>
+        </div>
+        <div className="px-2">
+          <Separator orientation="vertical" />
+        </div>
+        <Dialog open={isResetDialogOpen} onOpenChange={setIsResetDialogOpen}>
           <DialogTrigger asChild>
             <Button
               variant="outline"
@@ -101,7 +152,8 @@ export function Header() {
             </Button>
           </DialogTrigger>
           <DialogContent className="sm:max-w-[425px] space-y-2">
-            <DialogTitle>初期状態にリセットしますか？</DialogTitle>
+            <DialogTitle>すべてリセット</DialogTitle>
+            <DialogDescription>初期状態にリセットしますか？</DialogDescription>
             <Button
               onClick={() => {
                 resetMindMap();

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -43,11 +43,26 @@ export function Header() {
   // キーボードショートカット
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // 入力フィールドにフォーカスがある時はショートカットを無効化
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
       if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
         e.preventDefault();
         undo();
       }
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === "z") {
+      // Shiftキー押下時の大文字対応
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        e.shiftKey &&
+        (e.key === "z" || e.key === "Z")
+      ) {
         e.preventDefault();
         redo();
       }

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -60,7 +60,7 @@ export function Sidebar() {
   return (
     <div className="w-64 h-full bg-muted border-l flex flex-col overflow-auto">
       <div className="p-4 border-b">
-        <h2 className="font-pixel text-lg mb-2">
+        <h2 className="font-pixel text-lg">
           新規ブロックを追加
         </h2>
       </div>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -48,6 +48,7 @@ const Instructions = () => (
     <ol className="text-xs space-y-2 list-disc pl-5">
       <li>ブロックをクリックして選択</li>
       <li>ブロックをドラッグして移動</li>
+      <li>Ctrl+Z で操作を戻す、Ctrl+Shift+Z でやり直し</li>
       <li>新規ブロックはサイドバーで作成</li>
       <li>ブロックをつなげてマインドマップを構築しましょう！</li>
       <li>ダブルクリックでズームできます</li>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -20,7 +20,7 @@ const TextBlockCreator = () => {
 
 
   return (
-    <div className="bg-white rounded-lg p-3 border-2">
+    <aside className="bg-white rounded-lg p-3 border-2">
       <h3 className="font-pixel text-sm mb-2 flex items-center">
         <Type className="w-4 h-4 mr-1" /> アイデア
       </h3>
@@ -37,7 +37,7 @@ const TextBlockCreator = () => {
       >
         追加する
       </Button>
-    </div>
+    </aside>
   );
 };
 

--- a/src/store/mind-map-store.ts
+++ b/src/store/mind-map-store.ts
@@ -42,9 +42,96 @@ export const edgesAtom = atomWithStorage<Edge[]>("mindmap-edges", initialEdges);
 // 選択中のノードを管理するアトム
 export const selectedNodeAtom = atom<Node | null>(null);
 
+// 履歴の型定義
+type HistoryState = {
+  nodes: Node[];
+  edges: Edge[];
+};
+
+// 履歴管理
+export const historyAtom = atom<{
+  past: HistoryState[];
+  future: HistoryState[];
+}>({
+  past: [],
+  future: [],
+});
+
+// 現在の状態を履歴に保存
+const MAX_HISTORY = 50; // 最大50件
+const saveToHistoryAtom = atom(null, (get, set) => {
+  const currentNodes = get(nodesAtom);
+  const currentEdges = get(edgesAtom);
+  const history = get(historyAtom);
+  
+  const newPast = [...history.past, { nodes: currentNodes, edges: currentEdges }];
+  
+  set(historyAtom, {
+    past: newPast.slice(-MAX_HISTORY), // 上限を超えたら古いものを削除
+    future: [], // 新しい操作で future をクリア
+  });
+});
+
+// Undo
+export const undoAtom = atom(null, (get, set) => {
+  const history = get(historyAtom);
+  
+  if (history.past.length === 0) return;
+  
+  const currentState = {
+    nodes: get(nodesAtom),
+    edges: get(edgesAtom),
+  };
+  
+  const previousState = history.past[history.past.length - 1];
+  const newPast = history.past.slice(0, -1);
+  
+  set(nodesAtom, previousState.nodes);
+  set(edgesAtom, previousState.edges);
+  set(historyAtom, {
+    past: newPast,
+    future: [currentState, ...history.future],
+  });
+});
+
+// Redo
+export const redoAtom = atom(null, (get, set) => {
+  const history = get(historyAtom);
+  
+  if (history.future.length === 0) return;
+  
+  const currentState = {
+    nodes: get(nodesAtom),
+    edges: get(edgesAtom),
+  };
+  
+  const nextState = history.future[0];
+  const newFuture = history.future.slice(1);
+  
+  set(nodesAtom, nextState.nodes);
+  set(edgesAtom, nextState.edges);
+  set(historyAtom, {
+    past: [...history.past, currentState],
+    future: newFuture,
+  });
+});
+
+// Undo/Redo 可能かどうかのアトム
+export const canUndoAtom = atom((get) => get(historyAtom).past.length > 0);
+export const canRedoAtom = atom((get) => get(historyAtom).future.length > 0);
+
 
 // ノードを更新するアトム ... 変更があったノードを更新
 export const nodesChangeAtom = atom(null, (get, set, changes: NodeChange[]) => {
+  // ドラッグ終了を検出
+  const hasDragEnd = changes.some(
+    (c) => c.type === 'position' && 'dragging' in c && c.dragging === false
+  );
+  
+  if (hasDragEnd) {
+    set(saveToHistoryAtom);
+  }
+
   set(nodesAtom, applyNodeChanges(changes, get(nodesAtom))); // applyNodeChanges = React Flow の関数
 });
 
@@ -55,6 +142,7 @@ export const edgesChangeAtom = atom(null, (get, set, changes: EdgeChange[]) => {
 
 // ノード接続のアトム
 export const connectAtom = atom(null, (_, set, connection: Connection) => {
+  set(saveToHistoryAtom); // 履歴に保存
   set(edgesAtom, (eds) =>
     addEdge( // addEdge = React Flow の関数（何と何が繋がれたか取得）
       {
@@ -69,6 +157,8 @@ export const connectAtom = atom(null, (_, set, connection: Connection) => {
 
 // 子ノードを追加するアトム
 export const addChildNodeAtom = atom(null, (get, set, parentNode: Node) => {
+  set(saveToHistoryAtom); // 履歴に保存
+
   const nodes = get(nodesAtom);
   const newNodeId = `node_${nodes.length + 1}`; // id はユニークなもの
   const parentPosition = parentNode.position; // 親ノードのポジションを基準に配置
@@ -102,6 +192,8 @@ export const addChildNodeAtom = atom(null, (get, set, parentNode: Node) => {
 export const updateNodeLabelAtom = atom(
   null,
   (get, set, { nodeId, newLabel }: { nodeId: string; newLabel: string }) => {
+    set(saveToHistoryAtom); // 履歴に保存
+
     set(
       nodesAtom,
       get(nodesAtom).map((node) => {
@@ -125,6 +217,8 @@ export const deleteNodeAtom = atom(null, (get, set, nodeId: string) => {
   // ルートノードの削除を許可しない
   if (nodeId === "root") return;
 
+  set(saveToHistoryAtom); // 履歴に保存
+
   set(
     nodesAtom,
     get(nodesAtom).filter((node) => node.id !== nodeId)
@@ -139,6 +233,8 @@ export const deleteNodeAtom = atom(null, (get, set, nodeId: string) => {
 
 // テキストブロックを追加するアトム
 export const addTextBlockAtom = atom(null, (get, set, text: string) => {
+  set(saveToHistoryAtom); // 履歴に保存
+
   const nodes = get(nodesAtom);
   const newNodeId = `node_${nodes.length + 1}`;
 
@@ -158,6 +254,8 @@ export const addTextBlockAtom = atom(null, (get, set, text: string) => {
 
 // マインドマップをリセットするアトム
 export const resetMindMapAtom = atom(null, (_, set) => {
+  set(saveToHistoryAtom); // 履歴に保存
+
   set(nodesAtom, initialNodes);
   set(edgesAtom, initialEdges);
 });

--- a/src/store/mind-map-store.ts
+++ b/src/store/mind-map-store.ts
@@ -64,7 +64,7 @@ const saveToHistoryAtom = atom(null, (get, set) => {
   const currentEdges = get(edgesAtom);
   const history = get(historyAtom);
   
-  const newPast = [...history.past, { nodes: currentNodes, edges: currentEdges }];
+  const newPast = [...history.past, { nodes: [...currentNodes], edges: [...currentEdges] }];
   
   set(historyAtom, {
     past: newPast.slice(-MAX_HISTORY), // 上限を超えたら古いものを削除
@@ -121,16 +121,40 @@ export const canUndoAtom = atom((get) => get(historyAtom).past.length > 0);
 export const canRedoAtom = atom((get) => get(historyAtom).future.length > 0);
 
 
+// ドラッグ中のノードを追跡
+const draggingNodesAtom = atom<Set<string>>(new Set<string>());
+
 // ノードを更新するアトム ... 変更があったノードを更新
 export const nodesChangeAtom = atom(null, (get, set, changes: NodeChange[]) => {
-  // ドラッグ終了を検出
-  const hasDragEnd = changes.some(
-    (c) => c.type === 'position' && 'dragging' in c && c.dragging === false
+
+  const draggingNodes = get(draggingNodesAtom);
+
+   // ドラッグ開始を検出（dragging=true で、まだ追跡されていないノード）
+   const hasDragStart = changes.some(
+    (c) => c.type === 'position' && 
+           'dragging' in c && 
+           c.dragging === true && 
+           'id' in c && 
+           !draggingNodes.has(c.id)
   );
   
-  if (hasDragEnd) {
+  // ドラッグ開始時に履歴保存（変更前の状態を保存）
+  if (hasDragStart) {
     set(saveToHistoryAtom);
   }
+
+  // ドラッグ状態を更新
+  const newDraggingNodes = new Set(draggingNodes);
+  changes.forEach(c => {
+    if (c.type === 'position' && 'dragging' in c && 'id' in c) {
+      if (c.dragging) {
+        newDraggingNodes.add(c.id);
+      } else {
+        newDraggingNodes.delete(c.id);
+      }
+    }
+  });
+  set(draggingNodesAtom, newDraggingNodes);
 
   set(nodesAtom, applyNodeChanges(changes, get(nodesAtom))); // applyNodeChanges = React Flow の関数
 });


### PR DESCRIPTION
## 📝 概要
マインドマップアプリに Undo/Redo 機能を追加

## ✨ 主な変更点

### 履歴管理機能
- Jotai で履歴スタック（past/future）を実装
- 最大50件の履歴を保持（メモリ対策）
- ノードの追加・削除・編集・移動をすべて記録

### UI/UX
- Header に Undo/Redo ボタンを追加
- キーボードショートカット対応
  - `Ctrl+Z` (Mac: `Cmd+Z`) で Undo
  - `Ctrl+Shift+Z` (Mac: `Cmd+Shift+Z`) で Redo
- ボタンの有効/無効状態を適切に制御
- 入力フィールド編集中はショートカットを無効化

### セマンティックHTML改善
- メインエリアを `<main>` タグでラップ
- サイドバーを `<aside>` タグに変更
- アクセシビリティとSEO向上

### 技術的な実装
- ドラッグ**開始時**に履歴保存（ドラッグ終了時ではない）
- シャローコピーで履歴の独立性を確保
- ノード接続時も履歴保存に対応

## ✅ 動作確認
- [x] ノード追加後に Undo/Redo できる
- [x] ノード削除後に Undo/Redo できる
- [x] ノード編集後に Undo/Redo できる
- [x] ノード移動後に Undo/Redo できる
- [x] キーボードショートカットが動作する
- [x] 入力フィールド編集中はショートカットが無効化される
- [x] 履歴がない時にボタンが無効化される

## 🔗 関連Issue
Closes #1