### PR TITLE
fix:resetMindMapAtom to clear history and selected node state. The re…

### DIFF
--- a/src/store/mind-map-store.ts
+++ b/src/store/mind-map-store.ts
@@ -278,8 +278,13 @@ export const addTextBlockAtom = atom(null, (get, set, text: string) => {
 
 // マインドマップをリセットするアトム
 export const resetMindMapAtom = atom(null, (_, set) => {
-  set(saveToHistoryAtom); // 履歴に保存
+  // 履歴を保存せず、履歴もクリア
+  set(historyAtom, {
+    past: [],
+    future: [],
+  });
 
   set(nodesAtom, initialNodes);
   set(edgesAtom, initialEdges);
+  set(selectedNodeAtom, null); // 選択状態もクリア
 });


### PR DESCRIPTION
## リセット時に履歴もクリアするように修正
「全てリセット」を実行すると、リセット前の状態が履歴に保存されてしまい、Undo ボタンを押してリセット前の状態に戻れる挙動だったので、これを修正。
「全てリセット」は新しく始める操作なので履歴もクリアされるように修正

```ts
// src/store/mind-map-store.ts

// マインドマップをリセットするアトム
export const resetMindMapAtom = atom(null, (_, set) => {
  // 履歴を保存せず、履歴もクリア
  set(historyAtom, {
    past: [],
    future: [],
  });

  set(nodesAtom, initialNodes);
  set(edgesAtom, initialEdges);
  set(selectedNodeAtom, null); // 選択状態もクリア
});
```